### PR TITLE
Set platform linux/amd64 fior build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     build:
       dockerfile: Dockerfile
       context: open-webui
+      platforms:
+        - "linux/amd64"
       args:
         USE_CUDA: false
         USE_OLLAMA: false


### PR DESCRIPTION
Set platform `linux/amd64` fior build to enable build on non-amd platforms. 